### PR TITLE
Refactor transaction controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ console.log($msgStore); // 'old value'
 Writing and pushing actions to the undo stack might create a lot of boilerplate code. The use of Transaction simplifies this.
 
 ```ts
-import { undoStack, TransactionCtrl } from '@gira-de/svelte-undo';
+import { undoStack, transactionCtrl } from '@gira-de/svelte-undo';
 
 // create undo stack with transaction controller
 const myUndoStack = undoStack('created');
-const transactionCtrl = new TransactionCtrl(myUndoStack, 'commit');
+const myTransactionCtrl = transactionCtrl(myUndoStack, 'commit');
 const personStore = writable({ name: 'John', age: '23' });
 
 // create a draft state for the person store
-let personDraft = transactionCtrl.getDraft(personStore);
+let personDraft = myTransactionCtrl.draft(personStore);
 personDraft['age'] = 24;
 
 // apply all draft changes
-transactionCtrl.commit('happy birthday');
+myTransactionCtrl.commit('happy birthday');
 console.log($personStore); // { name: 'John', age: '24' }
 
 // call undo() to revert the changes
@@ -60,16 +60,16 @@ Limitations: The transaction controller can only be used with Svelte stores that
 ### Save & Load undo stack
 
 ```ts
-import { undoStack, TransactionCtrl } from '@gira-de/svelte-undo';
+import { undoStack, transactionCtrl } from '@gira-de/svelte-undo';
 
 // new undo stack
 const myUndoStack = undoStack('created');
-const transactionCtrl = new TransactionCtrl(myUndoStack, 'sub action');
+const myTransactionCtrl = transactionCtrl(myUndoStack, 'sub action');
 
 // create an undo step
 const personStore = writable({ name: 'John', age: '23' });
-transactionCtrl.getDraft(personStore)['age'] = 24;
-transactionCtrl.commit('happy birthday');
+myTransactionCtrl.draft(personStore)['age'] = 24;
+myTransactionCtrl.commit('happy birthday');
 
 // create a snapshot of the current state
 const stores = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { undoStack } from './undo-stack';
-export { TransactionCtrl } from './transaction';
+export { transactionCtrl } from './transaction';
 export { InitAction } from './action/action-init';
 export { GroupAction } from './action/action-group';
 export { SetAction } from './action/action-set';

--- a/src/transaction.test.ts
+++ b/src/transaction.test.ts
@@ -1,49 +1,49 @@
 import { undoStack } from './undo-stack';
 import { get, writable } from 'svelte/store';
-import { TransactionCtrl } from './transaction';
+import { transactionCtrl } from './transaction';
 
 describe('transactionCtrl', () => {
   test('should return current draft', () => {
     const undoStack1 = undoStack('created');
-    const transactionCtrl = new TransactionCtrl(undoStack1, 'commit');
+    const transactionCtrl1 = transactionCtrl(undoStack1, 'commit');
     const store1 = writable<Record<string, unknown>>({});
 
-    let draft1 = transactionCtrl.getDraft(store1);
+    let draft1 = transactionCtrl1.draft(store1);
     draft1['a'] = 1;
 
-    draft1 = transactionCtrl.getDraft(store1);
+    draft1 = transactionCtrl1.draft(store1);
     expect(draft1['a']).toBe(1);
   });
 
   test('should commit store value', () => {
     const undoStack1 = undoStack('created');
-    const transactionCtrl = new TransactionCtrl(undoStack1, 'commit');
+    const transactionCtrl1 = transactionCtrl(undoStack1, 'commit');
     const store1 = writable<Record<string, unknown>>({});
 
-    const draft1 = transactionCtrl.getDraft(store1);
+    const draft1 = transactionCtrl1.draft(store1);
     draft1['a'] = 1;
     expect(get(store1)).toEqual({});
 
-    transactionCtrl.commit('commit');
+    transactionCtrl1.commit('commit');
     expect(get(store1)).toEqual({ a: 1 });
     expect(get(undoStack1).canUndo).toBe(true);
   });
 
   test('should commit multiple store values', () => {
     const undoStack1 = undoStack('created');
-    const transactionCtrl = new TransactionCtrl(undoStack1, 'commit');
+    const transactionCtrl1 = transactionCtrl(undoStack1, 'commit');
     const store1 = writable<Record<string, unknown>>({});
     const store2 = writable<string[]>([]);
 
-    const draft1 = transactionCtrl.getDraft(store1);
+    const draft1 = transactionCtrl1.draft(store1);
     draft1['a'] = 1;
     expect(get(store1)).toEqual({});
 
-    const draft2 = transactionCtrl.getDraft(store2);
+    const draft2 = transactionCtrl1.draft(store2);
     draft2.push('x');
     expect(get(store2)).toEqual([]);
 
-    transactionCtrl.commit('commit');
+    transactionCtrl1.commit('commit');
     expect(get(store1)).toEqual({ a: 1 });
     expect(get(store2)).toEqual(['x']);
     expect(get(undoStack1).canUndo).toBe(true);
@@ -51,22 +51,22 @@ describe('transactionCtrl', () => {
 
   test('should rollback store values', () => {
     const undoStack1 = undoStack('created');
-    const transactionCtrl = new TransactionCtrl(undoStack1, 'commit');
+    const transactionCtrl1 = transactionCtrl(undoStack1, 'commit');
     const store1 = writable<Record<string, unknown>>({});
     const store2 = writable<string[]>([]);
 
-    const draft1 = transactionCtrl.getDraft(store1);
+    const draft1 = transactionCtrl1.draft(store1);
     draft1['a'] = 1;
 
-    const draft2 = transactionCtrl.getDraft(store2);
+    const draft2 = transactionCtrl1.draft(store2);
     draft2.push('x');
 
-    transactionCtrl.rollback();
+    transactionCtrl1.rollback();
     expect(get(store1)).toEqual({});
     expect(get(store2)).toEqual([]);
     expect(get(undoStack1).canUndo).toBe(false);
 
-    transactionCtrl.commit('commit');
+    transactionCtrl1.commit('commit');
     expect(get(store1)).toEqual({});
     expect(get(store2)).toEqual([]);
     expect(get(undoStack1).canUndo).toBe(false);


### PR DESCRIPTION
To be consistent with the undoStack, the transaction controller is no longer a class. getDraft() has been renamed to draft()

old syntax:
```
const ctrl = new TransactionCtrl(...)
ctrl.getDraft(...)
```

new syntax:
```
const ctrl = transactionCtrl(....)
ctrl.draft(...)
```