### PR TITLE
fix: ticker should be 0 after loading a snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The _undoStack_ is basically a Svelte store with various properties and function
   - the index of the current _selectedAction_
   - e.g. is _0_ if _canUndo_ is false
 - $myUndoStack.**ticker**
-  - _0_ after the undo stack ist created or a snapshot has been loaded
+  - _0_ after the undo stack has been created, cleared or a snapshot has been loaded
   - gets increment by one after each each change on the undo stack (e.g. undo, redo, push, ...)
 
 #### Functions
@@ -172,7 +172,6 @@ The _undoStack_ is basically a Svelte store with various properties and function
   - the snapshot can be easily serialized since it does no contain any store references and so on
 - myUndoStack.**loadSnapshot(undoStackSnapshot, stores)**
   - clears the undo stack and then loads the specified snapshot
-  - after loading _ticker_ equals _actions.length_
 
 ### transactionCtrl
 

--- a/src/undo-stack.test.ts
+++ b/src/undo-stack.test.ts
@@ -311,6 +311,9 @@ describe('loadSnapshot', () => {
     expect(get(undoStack1).index).toBe(1);
     expect(get(undoStack1).canUndo).toBe(true);
     expect(get(undoStack1).canRedo).toBe(false);
+    expect(get(undoStack1).ticker).toBe(0);
+    expect(get(undoStack1).selectedAction).toBe(get(undoStack1).actions[1]);
+    expect(get(undoStack1).actions.map((a) => a.seqNbr)).toEqual([0, 1]);
 
     undoStack1.undo();
     expect(get(undoStack1).index).toBe(0);

--- a/src/undo-stack.ts
+++ b/src/undo-stack.ts
@@ -231,9 +231,8 @@ export function undoStack<TMsg>(initActionMsg: TMsg): UndoStack<TMsg> {
     stores: Record<string, unknown>,
   ) {
     const actions = loadActionsSnapshot(undoStackSnapshot.actions, stores);
-    let ticker = 0;
-    for (const action of actions) {
-      action.seqNbr = ticker++;
+    for (let i = 0; i < actions.length; i++) {
+      actions[i].seqNbr = i;
     }
 
     store.set({
@@ -241,7 +240,7 @@ export function undoStack<TMsg>(initActionMsg: TMsg): UndoStack<TMsg> {
       selectedAction: actions[undoStackSnapshot.index],
       canRedo: undoStackSnapshot.index < undoStackSnapshot.actions.length - 1,
       canUndo: undoStackSnapshot.index > 0,
-      ticker,
+      ticker: 0,
       index: undoStackSnapshot.index,
     });
   }


### PR DESCRIPTION
The ticker should be 0 after calling loadSnapshot(...)