### PR TITLE
Remove ticker and fix issue with seqNbr

### DIFF
--- a/.changeset/stupid-mugs-teach.md
+++ b/.changeset/stupid-mugs-teach.md
@@ -1,0 +1,5 @@
+---
+'@gira-de/svelte-undo': patch
+---
+
+remove: ticker from undo stack as its purpose is not really clear

--- a/.changeset/three-books-worry.md
+++ b/.changeset/three-books-worry.md
@@ -1,0 +1,5 @@
+---
+'@gira-de/svelte-undo': patch
+---
+
+fix: wrong seqNbr after erase() or clearUndo()

--- a/README.md
+++ b/README.md
@@ -147,9 +147,6 @@ The _undoStack_ is basically a Svelte store with various properties and function
 - $myUndoStack.**index**
   - the index of the current _selectedAction_
   - e.g. is _0_ if _canUndo_ is false
-- $myUndoStack.**ticker**
-  - _0_ after the undo stack is created, cleared or a snapshot has been loaded
-  - gets incremented by one after each each change on the undo stack (e.g. undo, redo, push, ...)
 
 #### Functions
 


### PR DESCRIPTION
- fix: The seqNbr for the erased actions was not set when calling erase() or clearUndo()
- improve: To ensure that the seqNbr is always unique it will be continued even if the undoStack is cleared or a snapshot is loaded. This also helps to identify the undo steps
- remove: The ticker has been removed since it's purpose is unclear