### PR TITLE
Remove unused package dependency prettier-plugin-svelte

### DIFF
--- a/.changeset/four-peaches-wink.md
+++ b/.changeset/four-peaches-wink.md
@@ -1,0 +1,5 @@
+---
+"@gira-de/svelte-undo": patch
+---
+
+Remove unused dev dependency prettier-plugin-svelte

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 /dist/
 /coverage/
 /pnpm-lock.yaml
+/.changeset/*.md

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@vitest/ui": "^1.4.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
-    "prettier-plugin-svelte": "^3.2.2",
     "svelte": "^4.2.12",
     "tslib": "^2.6.2",
     "typescript": "^5.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,6 @@ devDependencies:
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
-  prettier-plugin-svelte:
-    specifier: ^3.2.2
-    version: 3.2.2(prettier@3.2.5)(svelte@4.2.12)
   svelte:
     specifier: ^4.2.12
     version: 4.2.12
@@ -3278,16 +3275,6 @@ packages:
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-    dev: true
-
-  /prettier-plugin-svelte@3.2.2(prettier@3.2.5)(svelte@4.2.12):
-    resolution: {integrity: sha512-ZzzE/wMuf48/1+Lf2Ffko0uDa6pyCfgHV6+uAhtg2U0AAXGrhCSW88vEJNAkAxW5qyrFY1y1zZ4J8TgHrjW++Q==}
-    peerDependencies:
-      prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
-    dependencies:
-      prettier: 3.2.5
-      svelte: 4.2.12
     dev: true
 
   /prettier@2.8.8:


### PR DESCRIPTION
The Svelte prettier plugin is not used because this project doesn't contain any svelte-files. The dependency can be removed.

Also:
- prettier must ignore changesets